### PR TITLE
VP-818: Fix issue with failing buildx bake command.

### DIFF
--- a/docker-build-s3/action.yml
+++ b/docker-build-s3/action.yml
@@ -126,7 +126,7 @@ runs:
       run: |
         docker buildx bake "https://github.com/docker/buildx.git"
         mkdir -p ~/.docker/cli-plugins
-        mv ./bin/buildx ~/.docker/cli-plugins/docker-buildx
+        mv ./bin/build/buildx ~/.docker/cli-plugins/docker-buildx
 
     - name: Buildx version
       shell: bash


### PR DESCRIPTION
Path used for the buildx binary has changed. Cached builds were working but when the cache was cleared builds started failing because of invalid path for the binary. This change fixes the issue by using correct path for the binary as written in the latest
buildx documentation: https://github.com/docker/buildx#building.