### PR TITLE
docker-setup: skip Docker Hub login when no credentials

### DIFF
--- a/docker-setup/action.yml
+++ b/docker-setup/action.yml
@@ -52,7 +52,10 @@ runs:
       uses: docker/setup-buildx-action@v4
 
     - name: Login to Docker Hub
-      if: ${{ inputs.DOCKERHUB == 'true' }}
+      # Skip when no credentials are available (e.g. Dependabot or fork PRs,
+      # which don't get repository secrets). The build proceeds with anonymous
+      # Docker Hub pulls instead of failing on an empty username/password.
+      if: ${{ inputs.DOCKERHUB == 'true' && inputs.DOCKERHUB_USERNAME != '' }}
       uses: docker/login-action@v4
       with:
         username: ${{ inputs.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
In Dependabot and fork PRs repository secrets are unavailable, so DOCKERHUB_USERNAME/DOCKERHUB_TOKEN are empty and docker/login-action fails with "Username and password required", breaking every build that uses this action. Only attempt the login when a username is present; otherwise fall back to anonymous Docker Hub pulls.